### PR TITLE
🚸 Close current instance before uploading docs artifacts

### DIFF
--- a/laminci/_artifacts.py
+++ b/laminci/_artifacts.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from zipfile import ZipFile
 
+import lndb
 from lamin_logger import logger
 
 from ._env import get_package_name
@@ -18,6 +19,7 @@ def zip_docs_dir(zip_filename: str) -> None:
 
 
 def upload_docs_artifact() -> None:
+    lndb.close()
     import lamindb as ln
 
     if "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] != "push":


### PR DESCRIPTION
Can otherwise fail upon lamindb import if a corrupted instance is still dangling.