### PR TITLE
Automatically make Github releases

### DIFF
--- a/laminci/__main__.py
+++ b/laminci/__main__.py
@@ -60,7 +60,7 @@ def publish_github_release(
         subprocess.run(["gh", "--version"], check=True, stdout=subprocess.PIPE)
 
         try:
-            gh_rl_cmd = [
+            command = [
                 "gh",
                 "release",
                 "create",
@@ -72,8 +72,10 @@ def publish_github_release(
                 "--generate-notes",
             ]
             if version.is_prerelease:
-                gh_rl_cmd.append("--prerelease")
-            subprocess.run(gh_rl_cmd, check=True, stdout=subprocess.PIPE)
+                command.append("--prerelease")
+
+            print(f"\nrun: {command}")
+            subprocess.run(command, check=True, stdout=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
             raise SystemExit(f"Error creating GitHub release using `gh`: {e}")
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Fixes #27 

Approach:

1. Use gh if installed to use the set token cross-platform.
2. Else use PyGithub if installed. Check for GITHUB_TOKEN environment variable which commonly also stores the token. 
3. If also not available, ask user for input.
Fail if neither of the two available.


Tested in a separate repository:

![image](https://github.com/laminlabs/laminci/assets/21954664/d9c83b61-7bec-43ab-9d4c-56a25f213bd3)
