### PR TITLE
🎨 Remove lnschema-core installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"] # we want to be able to run this on 3.8
+        python-version: ["3.12"]
     timeout-minutes: 10
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,21 @@
+fail_fast: false
+default_language_version:
+  python: python3
+default_stages:
+  - commit
+  - push
+minimum_pre_commit_version: 2.12.0
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-        exclude: |
-          (?x)(
-              .github/workflows/latest-changes.jinja2
-          )
-      - id: check-yaml
-      - id: check-added-large-files
-  - repo: https://github.com/psf/black
-    rev: 22.6.0
-    hooks:
-      - id: black-jupyter
-  - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-black==0.3.3
-          - flake8-typing-imports==1.10.0
-        language_version: python3
-        args:
-          - --max-line-length=88
-          - --ignore=E203,W503,BLK100,TYP001
-        exclude: |
-          (?x)(
-              __init__.py
-          )
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2
+    rev: v4.0.0-alpha.4
     hooks:
       - id: prettier
+        exclude: |
+          (?x)(
+            docs/changelog.md
+          )
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.3.9
+    rev: 0.6.1
     hooks:
       - id: nbstripout
         exclude: |
@@ -42,23 +23,29 @@ repos:
               docs/examples/|
               docs/notes/
           )
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
     hooks:
-      - id: forbid-crlf
-      - id: remove-crlf
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.8.0
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, --unsafe-fixes]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
     hooks:
-      - id: isort
-        args: ["--profile", "black"]
+      - id: detect-private-key
+      - id: check-ast
+      - id: end-of-file-fixer
+        exclude: |
+          (?x)(
+              .github/workflows/latest-changes.jinja2
+            )
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: trailing-whitespace
+      - id: check-case-conflict
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.940
+    rev: v1.7.1
     hooks:
       - id: mypy
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
-    hooks:
-      - id: pydocstyle
-        args: # google style + __init__, see http://www.pydocstyle.org/en/stable/error_codes.html
-          - --ignore=D100,D101,D102,D103,D106,D107,D203,D204,D213,D215,D400,D401,D403,D404,D406,D407,D408,D409,D412,D413
+        args: [--no-strict-optional, --ignore-missing-imports]
+        additional_dependencies: ["types-requests", "types-attrs"]

--- a/docs/notes/YYYY-MM-DD-my-design-choice.ipynb
+++ b/docs/notes/YYYY-MM-DD-my-design-choice.ipynb
@@ -14,9 +14,7 @@
    "id": "97ec6631-8473-4a2d-b488-def921bb83de",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from nbproject import header"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/laminci/_artifacts.py
+++ b/laminci/_artifacts.py
@@ -28,10 +28,7 @@ def zip_docs():
 
 def upload_docs_artifact_aws() -> None:
     package_name, zip_filename = zip_docs()
-    run(
-        f"aws s3 cp {zip_filename} s3://lamin-site-assets/docs/{zip_filename}",
-        shell=True,
-    )
+    run(f"aws s3 cp {zip_filename} s3://lamin-site-assets/docs/{zip_filename}")
 
 
 def upload_docs_artifact_lamindb() -> None:
@@ -72,5 +69,5 @@ def upload_docs_artifact(aws: bool = False) -> None:
             upload_docs_artifact_lamindb()
 
         except ImportError:
-            warnings.warn("Fall back to AWS")
+            warnings.warn("Fall back to AWS", stacklevel=2)
             upload_docs_artifact_aws()

--- a/laminci/_db.py
+++ b/laminci/_db.py
@@ -27,8 +27,7 @@ def setup_local_test_postgres(name: str = "pgtest", version: Optional[str] = Non
         version = ""
     process = run(
         f"docker run --name {name} -e POSTGRES_PASSWORD=pwd"
-        f" -e POSTGRES_DB={name} -d -p 5432:5432 postgres{version}",  # noqa
-        shell=True,
+        f" -e POSTGRES_DB={name} -d -p 5432:5432 postgres{version}",
     )
     if process.returncode == 0:
         logger.info(

--- a/laminci/_doc_changes.py
+++ b/laminci/_doc_changes.py
@@ -33,12 +33,15 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from github import Github
-from github.PullRequest import PullRequest
 from jinja2 import Template
 from pydantic import BaseModel, SecretStr
 from pydantic_settings import BaseSettings
+
+if TYPE_CHECKING:
+    from github.PullRequest import PullRequest
 
 
 class Section(BaseModel):
@@ -209,8 +212,7 @@ def generate_content(
         new_release_content = updated_content
 
     new_content = (
-        f"{pre_header_content}\n\n{new_release_content}\n\n{post_release_content}"
-        .strip()
+        f"{pre_header_content}\n\n{new_release_content}\n\n{post_release_content}".strip()
         + "\n"
     )
     return new_content

--- a/laminci/_docs.py
+++ b/laminci/_docs.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from pathlib import Path
 
 from ._env import load_project_yaml
 
@@ -9,7 +10,7 @@ def move_built_docs_to_slash_project_slug():
         return
     yaml = load_project_yaml()
     shutil.move("_build/html", "_build/html_tmp")
-    os.makedirs("_build/html")
+    Path.mkdir("_build/html", parents=True)
     shutil.move("_build/html_tmp", f"_build/html/{yaml['project_slug']}")
 
 
@@ -18,5 +19,5 @@ def move_built_docs_to_docs_slash_project_slug():
         return
     yaml = load_project_yaml()
     shutil.move("_build/html", f"_build/{yaml['project_slug']}")
-    os.makedirs("_build/html/docs")
+    Path.mkdir("_build/html/docs", parents=True)
     shutil.move(f"_build/{yaml['project_slug']}", "_build/html/docs")

--- a/laminci/_docs_artifacts.py
+++ b/laminci/_docs_artifacts.py
@@ -27,11 +27,17 @@ def zip_docs():
     return repo_name, zip_filename
 
 
+# Ruff seems to ignore any noqa comments in the following and we therefore disable it briefly
+# ruff: noqa
 def upload_docs_artifact_aws() -> None:
     repo_name, zip_filename = zip_docs()
     run(
         f"aws s3 cp {zip_filename} s3://lamin-site-assets/docs/{zip_filename}",
+        shell=True,
     )
+
+
+# ruff: enable
 
 
 def upload_docs_artifact_lamindb() -> None:

--- a/laminci/_env.py
+++ b/laminci/_env.py
@@ -8,7 +8,7 @@ import yaml  # type: ignore
 def load_project_yaml(root_directory: Optional[Path] = None) -> dict:
     yaml_file = Path("lamin-project.yaml")
     if root_directory is None:
-        root_directory = Path(".")
+        root_directory = Path()
     yaml_file = root_directory / yaml_file
     with yaml_file.open() as f:
         d = yaml.safe_load(f)

--- a/laminci/_nox_logger.py
+++ b/laminci/_nox_logger.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import nox
 from nox.registry import _REGISTRY, Any, Callable, F, Func, Python, functools
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def session_decorator(

--- a/laminci/_run_notebooks.py
+++ b/laminci/_run_notebooks.py
@@ -7,5 +7,5 @@ def run_notebooks(file_or_folder: str | Path):
     import nbproject_test
 
     path = Path(file_or_folder)
-    assert path.exists()  # noqa: S101
+    assert path.exists()  # noqa: S101c
     nbproject_test.execute_notebooks(path.resolve(), write=True)

--- a/laminci/nox.py
+++ b/laminci/nox.py
@@ -125,7 +125,6 @@ def install_lamindb(
             "--system",
             "--no-deps",
             "./lamindb/sub/lamindb-setup",
-            "./lamindb/sub/lnschema-core",
             "./lamindb/sub/lamin-cli",
             "./lamindb/sub/bionty",
             "./lamindb/sub/wetlab",

--- a/laminci/nox.py
+++ b/laminci/nox.py
@@ -1,19 +1,19 @@
 import json
 import os
 import shlex
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict, Iterable, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 import nox
 from nox import Session
 
-from . import _nox_logger  # noqa, the import silences the logger
 from ._env import get_package_name
 
 SYSTEM = " --system " if os.getenv("CI") else ""
 
 
-def _login_lamin_user(user_email: str, env: Optional[Dict[str, str]] = None):
+def _login_lamin_user(user_email: str, env: Optional[dict[str, str]] = None):
     import boto3
     import lamindb_setup as ln_setup
 
@@ -36,16 +36,16 @@ def _login_lamin_user(user_email: str, env: Optional[Dict[str, str]] = None):
         raise NotImplementedError
 
 
-def login_testuser1(session: Session, env: Optional[Dict[str, str]] = None):
+def login_testuser1(session: Session, env: Optional[dict[str, str]] = None):
     _login_lamin_user("testuser1@lamin.ai", env=env)
 
 
-def login_testuser2(session: Session, env: Optional[Dict[str, str]] = None):
+def login_testuser2(session: Session, env: Optional[dict[str, str]] = None):
     _login_lamin_user("testuser2@lamin.ai", env=env)
 
 
 def run(session: Session, s: str, **kwargs):
-    assert (args := shlex.split(s))
+    assert (args := shlex.split(s))  # noqa: S101
     return session.run(*args, **kwargs)
 
 
@@ -58,7 +58,7 @@ def run_pre_commit(session: Session):
     session.run("pre-commit", "run", "--all-files")
 
 
-def run_pytest(session: Session, coverage: bool = True, env: Optional[Dict] = None):
+def run_pytest(session: Session, coverage: bool = True, env: Optional[dict] = None):
     package_name = get_package_name()
     coverage_args = (
         f"--cov={package_name} --cov-append --cov-report=term-missing".split()
@@ -93,7 +93,7 @@ def install_lamindb(
     branch: Literal["release", "main"],
     extras: Optional[Union[Iterable[str], str]] = None,
 ):
-    assert branch in {"release", "main"}
+    assert branch in {"release", "main"}  # noqa: S101
 
     if extras is None:
         extras_str = ""
@@ -101,7 +101,7 @@ def install_lamindb(
         if extras == "":
             extras_str = ""
         else:
-            assert "[" not in extras and "]" not in extras
+            assert "[" not in extras and "]" not in extras  # noqa: S101
             extras_str = f"[{extras}]"
     else:
         extras_str = f"[{','.join(extras)}]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,6 @@ dev = [
 [project.scripts]
 laminci = "laminci.__main__:main"
 
-[tool.black]
-preview = true
-
 [tool.pytest.ini_options]
 testpaths = [
     "tests",
@@ -52,3 +49,107 @@ testpaths = [
 omit = [
     "laminci/*",
 ]
+
+[tool.ruff]
+src = ["src"]
+line-length = 88
+lint.select = [
+    "F",  # Errors detected by Pyflakes
+    "E",  # Error detected by Pycodestyle
+    "W",  # Warning detected by Pycodestyle
+    "I",  # isort
+    "D",  # pydocstyle
+    "B",  # flake8-bugbear
+    "TID",  # flake8-tidy-imports
+    "C4",  # flake8-comprehensions
+    "BLE",  # flake8-blind-except
+    "UP",  # pyupgrade
+    "RUF100",  # Report unused noqa directives
+    "TCH",  # Typing imports
+    "NPY",  # Numpy specific rules
+    "PTH",  # Use pathlib
+    "S"  # Security
+]
+lint.ignore = [
+    # Do not catch blind exception: `Exception`
+    "BLE001",
+    # Errors from function calls in argument defaults. These are fine when the result is immutable.
+    "B008",
+    # line too long -> we accept long comment lines; black gets rid of long code lines
+    "E501",
+    # Do not assign a lambda expression, use a def -> lambda expression assignments are convenient
+    "E731",
+    # allow I, O, l as variable names -> I is the identity matrix
+    "E741",
+    # Missing docstring in public module
+    "D100",
+    # undocumented-public-class
+    "D101",
+    # Missing docstring in public method
+    "D102",
+    # Missing docstring in public function
+    "D103",
+    # Missing docstring in public package
+    "D104",
+    # __magic__ methods are are often self-explanatory, allow missing docstrings
+    "D105",
+    # Missing docstring in public nested class
+    "D106",
+    # Missing docstring in __init__
+    "D107",
+    ## Disable one in each pair of mutually incompatible rules
+    # We don’t want a blank line before a class docstring
+    "D203",
+    # 1 blank line required after class docstring
+    "D204",
+    # first line should end with a period [Bug: doesn't work with single-line docstrings]
+    # We want docstrings to start immediately after the opening triple quote
+    "D213",
+    # Section underline is over-indented ("{name}")
+    "D215",
+    # First line should end with a period
+    "D400",
+    # First line should be in imperative mood; try rephrasing
+    "D401",
+    # First word of the first line should be capitalized: {} -> {}
+    "D403",
+    # First word of the docstring should not be "This"
+    "D404",
+    # Section name should end with a newline ("{name}")
+    "D406",
+    # Missing dashed underline after section ("{name}")
+    "D407",
+    # Section underline should be in the line following the section's name ("{name}")
+    "D408",
+    # Section underline should match the length of its name ("{name}")
+    "D409",
+    # No blank lines allowed between a section header and its content ("{name}")
+    "D412",
+    # Missing blank line after last section ("{name}")
+    "D413",
+    # camcelcase imported as lowercase
+    "N813",
+    # module import not at top level of file
+    "E402",
+    # open()` should be replaced by `Path.open()
+    "PTH123",
+    # subprocess` call: check for execution of untrusted input - https://github.com/PyCQA/bandit/issues/333
+    "S603",
+    # Starting a process with a partial executable path
+    "S607"
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"docs/*" = ["I", "S101"]
+"tests/**/*.py" = [
+    "D",  # docstrings are allowed to look a bit off
+    "S101", # asserts allowed in tests...
+    "ARG", # Unused function args -> fixtures nevertheless are functionally relevant...
+    "FBT", # Don't care about booleans as positional arguments in tests, e.g. via @pytest.mark.parametrize()
+    "PLR2004", # Magic value used in comparison, ...
+    "S311", # Standard pseudo-random generators are not suitable for cryptographic purposes
+]
+"*/__init__.py" = ["F401"]

--- a/tests/test_package_name.py
+++ b/tests/test_package_name.py
@@ -2,4 +2,4 @@ from laminci import get_package_name
 
 
 def test_get_package_name():
-    get_package_name() == "laminci"
+    assert get_package_name() == "laminci"


### PR DESCRIPTION
We no longer have lnschema-core since it got merged with lamindb. This PR further updates the pre-commit config to also use the latest Ruff. Moreover, we increase the CI Python version to 3.12.